### PR TITLE
Play 2.6.0-M2 and Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module provides some support for @codahale [Metrics](https://dropwizard.git
 [![codecov.io](http://codecov.io/github/breadfan/metrics-play/coverage.svg?branch=master)](http://codecov.io/github/AutoScout24/metrics-play?branch=master)
 [![Download](https://api.bintray.com/packages/breadfan/maven/metrics-play/images/download.svg) ](https://bintray.com/breadfan/maven/metrics-play/_latestVersion)
 
-Play Version: 2.5.4 Metrics Version: 3.1.2, Scala Version: 2.11.8
+Play Version: 2.6.0-M2 Metrics Version: 3.2.2, Scala Version: 2.12.2
 
 ## Features
 
@@ -57,17 +57,19 @@ To enable the controller add a mapping to conf/routes file
      GET     /admin/metrics              com.kenshoo.play.metrics.MetricsController.metrics
      
 #### Configuration
-Some configuration is supported through the default configuration file:
 
-    metrics.rateUnit - (default is SECONDS) 
+Override values from the (metrics-reference.conf)[src/main/resources/metrics-reference.conf] as needed in your `application.conf`:
 
-    metrics.durationUnit (default is SECONDS)
-
-    metrics.showSamples [true/false] (default is false)
-
-    metrics.jvm - [true/false] (default is true) controls reporting jvm metrics
-  
-    metrics.logback - [true/false] (default is true) controls reporing logback metrics
+```HOCON
+metrics {
+     name: "default"
+     rateUnit: "SECONDS"
+     durationUnit: "SECONDS"
+     showSamples: false
+     jvm: true # reporting jvm metrics
+     logback: true # controls reporing logback metrics 
+}
+```
 
 ### Metrics Filter
 
@@ -139,6 +141,7 @@ instead of `com.kenshoo.play.metrics.PlayModule`
 
 ## Changes
 
+* 2.6.0-M2    - Supporting Play 2.6, added Scala 2.12, abandoning Scala 2.11
 * 2.5.13      - Supporting Play 2.5, abandoning Scala 2.10
 * 2.4.0_0.4.0 - Re-implement as Play Module
 * 2.4.0_0.3.0 - Upgrade to play 2.4, metrics 3.1.2

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization:= "de.threedimensions"
 name := "metrics-play"
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-val playVersion = "2.6.0-M2"
+val playVersion = "2.6.0-RC2"
 version in ThisBuild := playVersion + "_" + Properties.envOrElse("TRAVIS_BUILD_NUMBER", "0-SNAPSHOT")
 
 scalaVersion := "2.12.2"

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,13 @@
 import scala.util.Properties
-import bintray._
 
 organization:= "de.threedimensions"
 name := "metrics-play"
-licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-version in ThisBuild := "2.5." + Properties.envOrElse("TRAVIS_BUILD_NUMBER", "0-SNAPSHOT")
+val playVersion = "2.6.0-M2"
+version in ThisBuild := playVersion + "_" + Properties.envOrElse("TRAVIS_BUILD_NUMBER", "0-SNAPSHOT")
 
-scalaVersion := "2.11.8"
-
-val playVersion = "2.5.4"
+scalaVersion := "2.12.2"
 
 testOptions in Test += Tests.Argument("junitxml", "console")
 
@@ -18,14 +16,14 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-    "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
-    "io.dropwizard.metrics" % "metrics-json" % "3.1.2",
-    "io.dropwizard.metrics" % "metrics-jvm" % "3.1.2",
-    "io.dropwizard.metrics" % "metrics-logback" % "3.1.2",
-    "com.typesafe.play" %% "play" % "2.5.3" % "provided",
-    "org.joda" % "joda-convert" % "1.2",
-    //test
-    "com.typesafe.play" %% "play-test" % playVersion % "test",
-    "com.typesafe.play" %% "play-specs2" % playVersion % "test",
-    "org.specs2" %% "specs2" % "2.3.12" % "test"
+  "io.dropwizard.metrics" % "metrics-core" % "3.2.2",
+  "io.dropwizard.metrics" % "metrics-json" % "3.2.2",
+  "io.dropwizard.metrics" % "metrics-jvm" % "3.2.2",
+  "io.dropwizard.metrics" % "metrics-logback" % "3.2.2",
+  "com.typesafe.play" %% "play" % playVersion % "provided",
+  "org.joda" % "joda-convert" % "1.8.1",
+  //test
+  "com.typesafe.play" %% "play-test" % playVersion % "test",
+  "com.typesafe.play" %% "play-specs2" % playVersion % "test",
+  "org.specs2" %% "specs2" % "2.4.17" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M2")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/src/main/resources/metrics-reference.conf
+++ b/src/main/resources/metrics-reference.conf
@@ -1,0 +1,8 @@
+metrics {
+  name: "default"
+  rateUnit: "SECONDS"
+  durationUnit: "SECONDS"
+  showSamples: false
+  jvm: true
+  logback: true
+}

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
@@ -18,9 +18,9 @@ package com.kenshoo.play.metrics
 import javax.inject.Inject
 
 import play.api.http.ContentTypes
-import play.api.mvc.{Action, Controller, Headers}
+import play.api.mvc.InjectedController
 
-class MetricsController @Inject() (met: Metrics) extends Controller with ContentTypes {
+class MetricsController @Inject()(met: Metrics) extends InjectedController with ContentTypes {
 
   def metrics = Action {
     try {

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
@@ -17,17 +17,18 @@ package com.kenshoo.play.metrics
 
 import javax.inject.Inject
 
-import play.api.mvc.{Action, Controller}
+import play.api.http.ContentTypes
+import play.api.mvc.{Action, Controller, Headers}
 
-class MetricsController @Inject() (met: Metrics) extends Controller {
+class MetricsController @Inject() (met: Metrics) extends Controller with ContentTypes {
 
   def metrics = Action {
     try {
       Ok(met.toJson)
-        .as("application/json")
-        .withHeaders("Cache-Control" -> "must-revalidate,no-cache,no-store")
+        .as(JSON)
+        .withHeaders(CACHE_CONTROL → "must-revalidate,no-cache,no-store")
     } catch {
-      case ex: MetricsDisabledException =>
+      case ex: MetricsDisabledException ⇒
         InternalServerError("metrics plugin not enabled")
     }
   }

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -20,23 +20,21 @@ import javax.inject.Inject
 import akka.stream.Materializer
 import play.api.mvc._
 import play.api.http.Status
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
 import com.codahale.metrics._
 import com.codahale.metrics.MetricRegistry.name
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 trait MetricsFilter extends Filter
 
 class DisabledMetricsFilter @Inject() (implicit val mat: Materializer) extends MetricsFilter {
-  def apply(nextFilter: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+  def apply(nextFilter: (RequestHeader) ⇒ Future[Result])(rh: RequestHeader): Future[Result] = {
     nextFilter(rh)
   }
 }
 
-class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materializer) extends MetricsFilter {
+class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materializer, implicit val ec: ExecutionContext) extends MetricsFilter {
 
   def registry: MetricRegistry = metrics.defaultRegistry
 
@@ -59,14 +57,13 @@ class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materiali
     Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR, Status.CONFLICT,
     Status.UNAUTHORIZED, Status.NOT_MODIFIED)
 
-
-  def statusCodes: Map[Int, Meter] = knownStatuses.map(s => s -> registry.meter(name(labelPrefix, s.toString))).toMap
+  def statusCodes: Map[Int, Meter] = knownStatuses.map(s ⇒ s → registry.meter(name(labelPrefix, s.toString))).toMap
 
   def requestsTimer: Timer = registry.timer(name(labelPrefix, "requestTimer"))
   def activeRequests: Counter = registry.counter(name(labelPrefix, "activeRequests"))
   def otherStatuses: Meter = registry.meter(name(labelPrefix, "other"))
 
-  def apply(nextFilter: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+  def apply(nextFilter: (RequestHeader) ⇒ Future[Result])(rh: RequestHeader): Future[Result] = {
 
     val context = requestsTimer.time()
 
@@ -78,11 +75,11 @@ class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materiali
 
     activeRequests.inc()
     nextFilter(rh).transform(
-      result => {
+      result ⇒ {
         logCompleted(result)
         result
       },
-      exception => {
+      exception ⇒ {
         logCompleted(Results.InternalServerError)
         exception
       }

--- a/src/main/scala/com/kenshoo/play/metrics/PlayModule.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/PlayModule.scala
@@ -1,11 +1,11 @@
 package com.kenshoo.play.metrics
 
-import play.api.{Environment, Configuration}
 import play.api.inject.Module
+import play.api.{Configuration, Environment}
 
 class PlayModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.getBoolean("metrics.enabled").getOrElse(true)) {
+    if (configuration.get[Option[Boolean]]("metrics.enabled").getOrElse(true)) {
       Seq(
         bind[MetricsFilter].to[MetricsFilterImpl].eagerly,
         bind[Metrics].to[MetricsImpl].eagerly

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
@@ -16,6 +16,7 @@
 package com.kenshoo.play.metrics
 
 import org.specs2.mutable.Specification
+import play.api.mvc.ControllerHelpers
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
@@ -28,6 +29,7 @@ class MetricsControllerSpec extends Specification {
         def defaultRegistry = throw new NotImplementedError
         def toJson = "{}"
       })
+      controller.setControllerComponents(stubControllerComponents())
 
       val result = controller.metrics.apply(FakeRequest())
       contentAsString(result) must equalTo("{}")
@@ -38,6 +40,7 @@ class MetricsControllerSpec extends Specification {
     "return 500 if metrics module is disabled" in {
 
       val controller = new MetricsController(new DisabledMetrics())
+      controller.setControllerComponents(stubControllerComponents())
 
       val result = controller.metrics.apply(FakeRequest())
 

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsFilterSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsFilterSpec.scala
@@ -39,12 +39,12 @@ object MetricsFilterSpec extends Specification {
     def filters = Seq(metricsFilter)
   }
 
-  def withApplication[T](result: => Result)(block: Application => T): T = {
+  def withApplication[T](result: ⇒ Result)(block: Application ⇒ T): T = {
 
     lazy val application = new GuiceApplicationBuilder()
       .overrides(
         bind[Router].to(Router.from {
-          case _ => Action(result)
+          case _ ⇒ Action(result)
         }),
         bind[HttpFilters].to[Filters],
         bind[MetricsFilter].to[MetricsFilterImpl],
@@ -60,25 +60,25 @@ object MetricsFilterSpec extends Specification {
 
   "MetricsFilter" should {
 
-    "return passed response code" in withApplication(Ok("")) { _ =>
-      val result = route(FakeRequest()).get
+    "return passed response code" in withApplication(Ok("")) { implicit app ⇒
+      val result = route(app, FakeRequest()).get
       status(result) must equalTo(OK)
     }
 
-    "increment status code counter" in withApplication(Ok("")) { implicit app =>
-      Await.ready(route(FakeRequest()).get, Duration(2, "seconds"))
+    "increment status code counter" in withApplication(Ok("")) { implicit app ⇒
+      Await.ready(route(app, FakeRequest()).get, Duration(2, "seconds"))
       val meter = metrics.defaultRegistry.meter(MetricRegistry.name(labelPrefix, "200"))
       meter.getCount must equalTo(1)
     }
 
-    "increment status code counter for uncaught exceptions" in withApplication(throw new RuntimeException("")) { implicit app =>
-      Await.ready(route(FakeRequest()).get, Duration(2, "seconds"))
+    "increment status code counter for uncaught exceptions" in withApplication(throw new RuntimeException("")) { implicit app ⇒
+      Await.ready(route(app, FakeRequest()).get, Duration(2, "seconds"))
       val meter = metrics.defaultRegistry.meter(MetricRegistry.name(labelPrefix, "500"))
       meter.getCount must equalTo(1)
     }
 
-    "increment request timer" in withApplication(Ok("")) { implicit app =>
-      Await.ready(route(FakeRequest()).get, Duration(2, "seconds"))
+    "increment request timer" in withApplication(Ok("")) { implicit app ⇒
+      Await.ready(route(app, FakeRequest()).get, Duration(2, "seconds"))
       val timer = metrics.defaultRegistry.timer(MetricRegistry.name(labelPrefix, "requestTimer"))
       timer.getCount must beGreaterThan(0L)
     }

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
@@ -10,6 +10,8 @@ import scala.collection.JavaConverters._
 
 class MetricsSpec extends Specification {
 
+  isolated
+
   def withApplication[T](conf: Map[String, Any])(block: Application ⇒ T): T = {
 
     lazy val application = new GuiceApplicationBuilder()
@@ -34,7 +36,7 @@ class MetricsSpec extends Specification {
       metrics.defaultRegistry.counter("my-counter").inc()
 
       val jsValue: JsValue = Json.parse(metrics.toJson)
-      (jsValue \ "counters" \ "my-counter" \ "count").as[Int] mustEqual(1)
+      (jsValue \ "counters" \ "my-counter" \ "count").as[Int] mustEqual 1
     }
 
     "contain JVM metrics" in withApplication(Map.empty) { implicit app ⇒
@@ -46,11 +48,11 @@ class MetricsSpec extends Specification {
     }
 
     "be able to turn off JVM metrics" in withApplication(Map("metrics.jvm" → false)) { implicit app ⇒
-      metrics.defaultRegistry.getGauges.asScala must not haveKey("jvm.attribute.name")
+      metrics.defaultRegistry.getGauges.asScala must not haveKey "jvm.attribute.name"
     }
 
     "be able to turn off logback metrics" in withApplication(Map("metrics.jvm" → "false", "metrics.logback" → false)) { implicit app ⇒
-      metrics.defaultRegistry.getMeters.asScala must not haveKey("ch.qos.logback.core.Appender.all")
+      metrics.defaultRegistry.getMeters.asScala must not haveKey "ch.qos.logback.core.Appender.all"
     }
   }
 }

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 class MetricsSpec extends Specification {
 
-  def withApplication[T](conf: Map[String, Any])(block: Application => T): T = {
+  def withApplication[T](conf: Map[String, Any])(block: Application ⇒ T): T = {
 
     lazy val application = new GuiceApplicationBuilder()
       .configure(conf)
@@ -25,31 +25,31 @@ class MetricsSpec extends Specification {
 
   "Metrics" should {
 
-    "serialize to JSON" in withApplication(Map("metrics.jvm" -> "false")) { implicit app =>
+    "serialize to JSON" in withApplication(Map("metrics.jvm" → "false")) { implicit app ⇒
       val jsValue: JsValue = Json.parse(metrics.toJson)
-      (jsValue \ "version").as[String] mustEqual "3.0.0"
+      (jsValue \ "version").as[String] mustEqual "3.1.3"
     }
 
-    "be able to add custom counter" in withApplication(Map("metrics.jvm" -> "false")) { implicit app =>
+    "be able to add custom counter" in withApplication(Map("metrics.jvm" → "false")) { implicit app ⇒
       metrics.defaultRegistry.counter("my-counter").inc()
 
       val jsValue: JsValue = Json.parse(metrics.toJson)
       (jsValue \ "counters" \ "my-counter" \ "count").as[Int] mustEqual(1)
     }
 
-    "contain JVM metrics" in withApplication(Map.empty) { implicit app =>
+    "contain JVM metrics" in withApplication(Map.empty) { implicit app ⇒
       metrics.defaultRegistry.getGauges.asScala must haveKey("jvm.attribute.name")
     }
 
-    "contain logback metrics" in withApplication(Map("metrics.jvm" -> "false")) { implicit app =>
+    "contain logback metrics" in withApplication(Map("metrics.jvm" → "false")) { implicit app ⇒
       metrics.defaultRegistry.getMeters.asScala must haveKey("ch.qos.logback.core.Appender.all")
     }
 
-    "be able to turn off JVM metrics" in withApplication(Map("metrics.jvm" -> false)) { implicit app =>
+    "be able to turn off JVM metrics" in withApplication(Map("metrics.jvm" → false)) { implicit app ⇒
       metrics.defaultRegistry.getGauges.asScala must not haveKey("jvm.attribute.name")
     }
 
-    "be able to turn off logback metrics" in withApplication(Map("metrics.jvm" -> "false", "metrics.logback" -> false)) { implicit app =>
+    "be able to turn off logback metrics" in withApplication(Map("metrics.jvm" → "false", "metrics.logback" → false)) { implicit app ⇒
       metrics.defaultRegistry.getMeters.asScala must not haveKey("ch.qos.logback.core.Appender.all")
     }
   }


### PR DESCRIPTION
**Version Bumps**

- Playframework version bump from _2.5.4_ to _2.6.0-M2_
- Upgraded from Scala _2.11_ to _2.12_
- SBT version bump from _0.13.11_ to _0.13.15_
- Version bumped outdated project libs

**Updates**

- introduced a
[metrics-reference.conf](src/main/resources/metrics-reference.conf] for
        this plugin
- minor updates (e.g. filters, tests) due to interface changes that came with Play 2.6 (see
    documentation)

Also, see [Play 2.6 Migration
Documentaion](https://playframework.com/documentation/2.6.x/Migration26)